### PR TITLE
Fix: Use temp file for metadata in prototype generator

### DIFF
--- a/prototypes/backend/api.py
+++ b/prototypes/backend/api.py
@@ -6,6 +6,8 @@ import time
 import socket
 import signal
 import sys
+import json
+import tempfile
 
 app = Flask(__name__)
 
@@ -108,10 +110,24 @@ def generate_prototype():
     name = data.get('name')
     system = data.get('system')
     metadata = data.get('metadata')
-    try:
-        subprocess.run([GENERATOR_PATH, id, system, name, metadata], check=True)
-    except subprocess.CalledProcessError:
-        return f"Failed to generate prototype, id={id}", 500
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        metadata_path = f"{temp_dir}/metadata.json"
+
+        with open(metadata_path, 'w', encoding='utf-8') as f:
+            # Already serialized as a JSON string
+            if isinstance(metadata, str):
+                f.write(metadata)
+            # Not serialized, serialize it
+            else:
+                json.dump(metadata, f)
+
+        try:
+            subprocess.run([GENERATOR_PATH, id, system, name, metadata_path], check=True)
+        except subprocess.CalledProcessError:
+            return f"Failed to generate prototype, id={id}", 500
+        except OSError as e:
+            return f"Failed to start generator process: {e}", 500
 
     # TODO: this database retrieval should be done using ids
     if 'database_prototype_name' in data:
@@ -140,4 +156,4 @@ def remove_prototype():
 
 
 if __name__ == '__main__':
-    app.run(host='127.0.0.1', port=os.environ.get('PORT', 8010), debug=False)
+    app.run(host='0.0.0.0', port=os.environ.get('PORT', 8010), debug=False)

--- a/prototypes/backend/generation/generator.sh
+++ b/prototypes/backend/generation/generator.sh
@@ -3,7 +3,8 @@
 export PROJECT_ID=$1
 export PROJECT_SYSTEM=$2
 export PROJECT_NAME=$3
-export METADATA="$4"
+export METADATA_FILE="$4"
+export METADATA="$(cat "$METADATA_FILE")"
 export WORKDIR=/usr/src/prototypes/backend/generation
 export OUTDIR=/usr/src/prototypes/generated_prototypes
 export ROOT=/usr/src/prototypes/


### PR DESCRIPTION
Use temporary files to send the metadata to the generator shell script. This is needed because some projects have metadata that is too large to pass directly as a command-line argument, causing `OSError: [Errno 7] Argument list too long`.